### PR TITLE
Moves sign-out to hype menu

### DIFF
--- a/packages/next-frontend/components/hype-menu.tsx
+++ b/packages/next-frontend/components/hype-menu.tsx
@@ -5,9 +5,10 @@ import Link from "next/link";
 interface HypeMenuProps {
 	balance: number;
 	isOpen: boolean;
+	onSignOut: () => void;
 }
 
-export default function HypeMenu({ balance, isOpen }: HypeMenuProps) {
+export default function HypeMenu({ balance, isOpen, onSignOut }: HypeMenuProps) {
 	return (
 		<ul className={classNames({ [styles.isOpen]: isOpen }, styles.hypeMenu)}>
 			<li className={styles.divider}> 
@@ -15,17 +16,21 @@ export default function HypeMenu({ balance, isOpen }: HypeMenuProps) {
 					$HYPE: {balance}
 				</div>
 			</li>
-			<li> 
+			<li className={styles.divider}> 
 				<Link href={'/token/board'}>
 					<a className={styles.link}>Leaderboard</a>
 				</Link>
 			</li>
-			{/* <li>
+			{/* <li className={styles.divider}>
 				<Link href={'/token/send'}> 
 					<a className={styles.link}>Send</a>
 				</Link>
 			</li> */}
-			
+			<li> 
+				<Link href={'/'}>
+					<a className={styles.link} onClick={onSignOut}>Sign Out</a>
+				</Link>
+			</li>
 		</ul>
 	)
 }

--- a/packages/next-frontend/components/hype-registration-button.tsx
+++ b/packages/next-frontend/components/hype-registration-button.tsx
@@ -132,15 +132,10 @@ export default function HypeRegistrationButton() {
 				</button>
 			)}
 
-			{isConnected && (
-				<button className={classNames(utilStyles.noStyle, utilStyles.infoIcon, styles.signOutIcon, { [styles.single]: isRegistered })} onClick={signOut}>
-					<HighlightOffOutlinedIcon fontSize="small" />
-				</button>
-			)}
-
 			<Menu 
 				balance={hypeBalance}
 				isOpen={hypeMenuOpen}
+				onSignOut={signOut}
 			/>
 
 			<Modal


### PR DESCRIPTION
# Motivation
The tiny icon button that performs the wallet sign-out is not very user-friendly and should be replaced with something more accessible. Since more wallet- / account-centric actions will be available through the hype menu, signing out from there feels natural.

# Specification / Implementation
Removes the "close icon" and adds new entry "Sign Out" with the same functionality. In conjunction with the soon to come "Send" entry (pull request https://github.com/HypeDAO/HypeDAO/pull/24), this would look pretty neat:

![HypeMenu-SignOut-anonymous](https://user-images.githubusercontent.com/20012009/132584929-9b66fc80-f924-4b11-b175-df19e70d7714.png)

