### PR TITLE
Fix Github action for dao-stats installation

### DIFF
--- a/scripts/tools/dao-stats/install.sh
+++ b/scripts/tools/dao-stats/install.sh
@@ -2,4 +2,4 @@
 
 cd packages/dao-stats/
 yarn install
-sudo yarn install -g .
+sudo yarn global add .


### PR DESCRIPTION
Fixes Github action by updating deprecated yarn command.